### PR TITLE
Fix issue with grafana-specific data not persisting

### DIFF
--- a/manifests/grafana/deployment.yaml
+++ b/manifests/grafana/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           # timeoutSeconds: 1
         volumeMounts:
         - name: grafana-persistent-storage
-          mountPath: /var
+          mountPath: /var/lib/grafana
       volumes:
       - name: grafana-persistent-storage
         emptyDir: {}


### PR DESCRIPTION
Using /var would remove grafana-specific data whereas using /var/lib/grafana as per the official Dockerfile reference states, it works as expected after pod deletion(s).